### PR TITLE
Feat : 카테고리 태그 컴포넌트 구현 (해시태그 역할)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,6 @@ import CategoryTagGroup from "./components/category-tag/CategoryTagGroup";
 
 const Wrap = styled.div`
   display: flex;
-  flex-direction: column;
   gap: 0.5rem;
 `;
 
@@ -13,7 +12,7 @@ function App() {
   const mockTagArray = ["시설", "설비", "냉난방"];
   return (
     <Wrap>
-      <CategoryTag contents="시설" />
+      <CategoryTag contents="예시" />
       <CategoryTagGroup tagArray={mockTagArray} />
     </Wrap>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,20 @@
 import styled from "@emotion/styled";
 import CategoryTag from "./components/category-tag/CategoryTag";
 import "./reset.css";
+import CategoryTagGroup from "./components/category-tag/CategoryTagGroup";
 
 const Wrap = styled.div`
   display: flex;
+  flex-direction: column;
   gap: 0.5rem;
 `;
 
 function App() {
+  const mockTagArray = ["시설", "설비", "냉난방"];
   return (
     <Wrap>
       <CategoryTag contents="시설" />
-      <CategoryTag contents="설비" />
-      <CategoryTag contents="냉난방" />
+      <CategoryTagGroup tagArray={mockTagArray} />
     </Wrap>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,20 @@
-import "./reset.css"
+import styled from "@emotion/styled";
+import CategoryTag from "./components/category-tag/CategoryTag";
+import "./reset.css";
+
+const Wrap = styled.div`
+  display: flex;
+  gap: 0.5rem;
+`;
 
 function App() {
-  return
+  return (
+    <Wrap>
+      <CategoryTag contents="시설" />
+      <CategoryTag contents="설비" />
+      <CategoryTag contents="냉난방" />
+    </Wrap>
+  );
 }
 
 export default App;

--- a/src/components/category-tag/CategoryTag.tsx
+++ b/src/components/category-tag/CategoryTag.tsx
@@ -1,0 +1,26 @@
+import styled from "@emotion/styled";
+
+const Container = styled.div`
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0 0.7rem;
+  background-color: var(--gray2-subbtn);
+  color: var(--gray5-lowText);
+  border-radius: 20px;
+  min-width: 45px;
+`;
+const Contents = styled.p``;
+
+interface CategoryTag {
+  contents: string;
+}
+const CategoryTag = ({ contents = "내용" }: CategoryTag) => {
+  return (
+    <Container>
+      <Contents>{contents}</Contents>
+    </Container>
+  );
+};
+
+export default CategoryTag;

--- a/src/components/category-tag/CategoryTagGroup.tsx
+++ b/src/components/category-tag/CategoryTagGroup.tsx
@@ -1,0 +1,21 @@
+import styled from "@emotion/styled";
+import CategoryTag from "./CategoryTag";
+
+interface CategoryTagGroupProps {
+  tagArray: string[];
+}
+const GroupContainer = styled.div`
+  display: flex;
+  gap: 0.5rem;
+`;
+const CategoryTagGroup = ({ tagArray }: CategoryTagGroupProps) => {
+  return (
+    <GroupContainer>
+      {tagArray.map((tagItem, index) => (
+        <CategoryTag key={index} contents={tagItem} />
+      ))}
+    </GroupContainer>
+  );
+};
+
+export default CategoryTagGroup;


### PR DESCRIPTION
## 📝작업 내용

<image src='https://github.com/user-attachments/assets/b91a8ceb-22fa-44d6-a70e-4c3aceaf4f22' width='300px'/>

* "예시" 는 CategoryTag 컴포넌트
* "시설, 설비, 냉난방" 은 CategoryTagGroup 컴포넌트

### 사용방법
```jsx
function App() {
  const mockTagArray = ["시설", "설비", "냉난방"];
  return (
    <Wrap>
      <CategoryTagGroup tagArray={mockTagArray} />
    </Wrap>
  );
}
```
* 배열로 데이터를 입력해 주면, 이를 순회하며 CategoryTag 컴포넌트를 출력 (배열에 있는 텍스트가 순차적으로 CategoryTag 컴포넌트로 입력됨)

## 💬리뷰 요구사항
코드를 직접 pull 해보시고, 문제가 있다면 편하게 말씀해 주세요!
