### PR TITLE
Feat : 검색-필터 바 컴포넌트 제작

### DIFF
--- a/src/components/content-bubble/ContentBubble.tsx
+++ b/src/components/content-bubble/ContentBubble.tsx
@@ -1,5 +1,5 @@
+import React, { CSSProperties, forwardRef } from "react";
 import styled from "@emotion/styled";
-import HeaderNavigator from "./contents/HeaderNavigator";
 
 const BubbleLayout = styled.div<TypeProps>`
   //컴포넌트 확인용, 삭제 예정
@@ -49,14 +49,18 @@ interface TypeProps {
   tailType: string;
 }
 interface ContentProps extends TypeProps {
-  content: React.ReactNode;
+  children: React.ReactNode;
+  style?: CSSProperties;
 }
 
-const ContentBubble = ({
-  content = <HeaderNavigator />,
-  tailType = "edge",
-}: ContentProps) => {
-  return <BubbleLayout tailType={tailType}>{content}</BubbleLayout>;
-};
+const ContentBubble = forwardRef<HTMLDivElement, ContentProps>(
+  ({ children, tailType = "edge" }, ref) => {
+    return (
+      <BubbleLayout ref={ref} tailType={tailType}>
+        {children}
+      </BubbleLayout>
+    );
+  }
+);
 
 export default ContentBubble;

--- a/src/components/filter-bar/FilterBar.tsx
+++ b/src/components/filter-bar/FilterBar.tsx
@@ -1,0 +1,100 @@
+import styled from "@emotion/styled";
+import FilterAltRoundedIcon from "@mui/icons-material/FilterAltRounded";
+import StatusButtonGroup from "../status-button/StatusButtonGroup";
+
+const Container = styled.div`
+  width: 100%;
+  height: auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0px 28px;
+  border-radius: 500px;
+  gap: 16px;
+  background-color: var(--gray1-background);
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
+    padding: 16px 20px;
+  }
+`;
+
+const SearchBar = styled.div`
+  display: flex;
+  align-items: center;
+  width: 352px;
+  height: 35px;
+  border-radius: 500px;
+  background-color: var(--white);
+  padding: 0 10px;
+  overflow: hidden;
+
+  @media (max-width: 768px) {
+    width: 80%;
+    height: 35px;
+  }
+`;
+
+const SearchInput = styled.input`
+  border: none;
+  outline: none;
+  flex-grow: 1;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  letter-spacing: -0.02em;
+  padding: 0 10px;
+  color: var(--gray5-lowText);
+  min-width: 0;
+
+  &::placeholder {
+    color: var(--gray4-placeholder-low);
+  }
+`;
+
+const SearchTextWrapper = styled.div`
+  color: var(--gray6-header);
+  margin-right: 8px;
+  margin-left: 8px;
+  white-space: nowrap;
+  line-height: 1.5rem; 
+`;
+
+const FilterIcon = styled(FilterAltRoundedIcon)`
+  color: var(--gray5-lowText);
+  cursor: pointer;
+  flex-shrink: 0;
+`;
+
+const StatusButtonGroupContainer = styled.div`
+  display: flex;
+  white-space: nowrap;
+align-items: center; /* 버튼을 세로 중앙 정렬 */
+  height: 35px;
+  @media (max-width: 768px) {
+    width: 100%;
+    justify-content: center;
+  }
+`;
+
+const FilterBar = () => {
+  return (
+    <Container>
+      {/* 왼쪽 해시태그 검색 */}
+      <SearchBar>
+        <SearchTextWrapper>해시태그</SearchTextWrapper>
+        <SearchInput placeholder="졸업" />
+        <FilterIcon />
+      </SearchBar>
+
+      {/* 오른쪽 상태 버튼 그룹 */}
+      <StatusButtonGroupContainer>
+        <StatusButtonGroup />
+      </StatusButtonGroupContainer>
+    </Container>
+  );
+};
+
+export default FilterBar;

--- a/src/components/header/Connect.tsx
+++ b/src/components/header/Connect.tsx
@@ -1,0 +1,132 @@
+import { useRef, useState, useEffect, CSSProperties } from "react";
+import Header from "./Header";
+import SideNavigator from "../side-navigator/SideNavigator";
+import ContentBubble from "../content-bubble/ContentBubble";
+import InfoMessage from "../info-message/InfoMessage";
+import { getColor } from "../../utils/InfoMessageUtils"; 
+
+const Connect = () => {
+  const [isOpen, setIsOpen] = useState({
+    isSideNavOpen: false,
+    contentBubble: false,
+    isMenu: false,
+  });
+
+  const sideNavRef = useRef<HTMLDivElement>(null);
+  const notificationIconRef = useRef<SVGSVGElement>(null);
+  const menuIconRef = useRef<SVGSVGElement>(null);
+  const contentBubbleRef = useRef<HTMLDivElement>(null);
+
+  // 알림 내용을 위한 임시 알림 데이터
+  const notifications = [
+    {
+      sizeType: "small",
+      messageType: "info",
+      content: "[저녁 수업 냉난방 가동 요청] 민원에 답변이 달렸습니다.",
+    },
+    {
+      sizeType: "small",
+      messageType: "message",
+      content: "[저녁 수업 냉난방 가동 요청] 민원에 댓글이 달렸습니다.",
+    },
+  ];
+
+  // 메뉴 항목
+  const menuItems = [
+    "마이페이지",
+    "내 민원",
+    "결과 조회",
+    "스크랩한 민원",
+    "개인정보 수정",
+  ];
+// infoMessage와 동일한 스타일 적용
+const menuItemStyle: CSSProperties = {
+  fontSize: "1rem",
+  color: getColor("message"),
+  display: "flex",
+  alignItems: "center",
+  gap: "0.5rem",
+  cursor: "pointer",
+};
+  const handleOpenSideNav = () => {
+    setIsOpen((prev) => ({ ...prev, isSideNavOpen: !prev.isSideNavOpen }));
+  };
+
+  const handleOpenContentBubble = (isMenu: boolean) => {
+    setIsOpen((prev) => ({ ...prev, contentBubble: !prev.contentBubble, isMenu }));
+  };
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as Node;
+
+      if (
+        isOpen.isSideNavOpen &&
+        sideNavRef.current &&
+        !sideNavRef.current.contains(target) &&
+        !notificationIconRef.current?.contains(target)
+      ) {
+        setIsOpen((prev) => ({ ...prev, isSideNavOpen: false }));
+      }
+
+      if (
+        isOpen.contentBubble &&
+        contentBubbleRef.current &&
+        !contentBubbleRef.current.contains(target) &&
+        !notificationIconRef.current?.contains(target)
+      ) {
+        setIsOpen((prev) => ({ ...prev, contentBubble: false }));
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isOpen]);
+
+  return (
+    <div>
+      <Header
+        onSideNavOpen={handleOpenSideNav}
+        onNotificationOpen={() => handleOpenContentBubble(false)}
+        onMenuOpen={() => handleOpenContentBubble(true)}
+        notificationIconRef={notificationIconRef}
+        menuIconRef={menuIconRef}
+      />
+      {isOpen.isSideNavOpen && <SideNavigator ref={sideNavRef} />}
+      {isOpen.contentBubble && (
+        <ContentBubble
+          ref={contentBubbleRef}
+          tailType={isOpen.isMenu ? "middle" : "edge"} //메뉴는 가운데, 알림은 가장자리쪽
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: "1rem", // 추가적인 padding을 주어 중앙 정렬 보장
+          }}
+        >
+          <div>
+            {isOpen.isMenu
+              ? menuItems.map((item, index) => (
+                  <div key={index} style={menuItemStyle}>
+                    {item}
+                  </div>
+                ))
+              : notifications.map((notification, index) => (
+                  <InfoMessage
+                    key={index}
+                    sizeType={notification.sizeType}
+                    messageType={notification.messageType}
+                    content={notification.content}
+                  />
+                ))}
+          </div>
+        </ContentBubble>
+      )}
+    </div>
+  );
+};
+
+export default Connect;

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -8,9 +8,11 @@ import PermIdentityRoundedIcon from "@mui/icons-material/PermIdentityRounded";
 import { useState } from "react";
 
 interface HeaderProps {
-  onMenuClick: () => void; 
-  onNotificationClick: () => void;
-  notificationIconRef: React.RefObject<HTMLDivElement>;
+  onSideNavOpen: () => void;
+  onNotificationOpen: () => void;
+  onMenuOpen: () => void;
+  notificationIconRef: React.RefObject<SVGSVGElement>;
+  menuIconRef: React.RefObject<SVGSVGElement>;
 }
 
 const Background = styled.div<BackgroundProps>`
@@ -68,18 +70,29 @@ const TempButton = styled.button`
   border: none;
 `;
 
-const Header = ({ onMenuClick }: HeaderProps) => {
+const Header = ({
+  onSideNavOpen,
+  onNotificationOpen,
+  onMenuOpen,
+  notificationIconRef,
+  menuIconRef,
+}: HeaderProps) => {
   const [isDark, setIsDark] = useState(false);
   //라우터 연결 뒤, useLocation으로 위치를 파악하여 헤더 색상 변경 예정
   const handleTempDark = () => {
     setIsDark((prev) => !prev);
   };
+
   return (
     <Background $isDark={isDark}>
       <HeaderContainer>
         {/*메뉴바 / 로고 */}
         <NavigatorSet>
-          <HeaderIcons $isDark={isDark} component={MenuRoundedIcon} onClick={onMenuClick} />
+          <HeaderIcons
+            $isDark={isDark}
+            component={MenuRoundedIcon}
+            onClick={onSideNavOpen}
+          />
           {isDark ? <LogoLight /> : <Logo />}
         </NavigatorSet>
         {/*알람 / 마이페이지 */}
@@ -87,8 +100,15 @@ const Header = ({ onMenuClick }: HeaderProps) => {
           <HeaderIcons
             $isDark={isDark}
             component={NotificationsNoneRoundedIcon}
+            onClick={onNotificationOpen}
+            ref={notificationIconRef}
           />
-          <HeaderIcons $isDark={isDark} component={PermIdentityRoundedIcon} />
+          <HeaderIcons
+            $isDark={isDark}
+            component={PermIdentityRoundedIcon}
+            onClick={onMenuOpen}
+            ref={menuIconRef}
+          />
         </NavigatorSet>
       </HeaderContainer>
       {/*라우터 구현 후 삭제 예정*/}

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -7,6 +7,12 @@ import NotificationsNoneRoundedIcon from "@mui/icons-material/NotificationsNoneR
 import PermIdentityRoundedIcon from "@mui/icons-material/PermIdentityRounded";
 import { useState } from "react";
 
+interface HeaderProps {
+  onMenuClick: () => void; 
+  onNotificationClick: () => void;
+  notificationIconRef: React.RefObject<HTMLDivElement>;
+}
+
 const Background = styled.div<BackgroundProps>`
   width: 100%;
   max-width: 1440px;
@@ -62,7 +68,7 @@ const TempButton = styled.button`
   border: none;
 `;
 
-const Header = () => {
+const Header = ({ onMenuClick }: HeaderProps) => {
   const [isDark, setIsDark] = useState(false);
   //라우터 연결 뒤, useLocation으로 위치를 파악하여 헤더 색상 변경 예정
   const handleTempDark = () => {
@@ -73,7 +79,7 @@ const Header = () => {
       <HeaderContainer>
         {/*메뉴바 / 로고 */}
         <NavigatorSet>
-          <HeaderIcons $isDark={isDark} component={MenuRoundedIcon} />
+          <HeaderIcons $isDark={isDark} component={MenuRoundedIcon} onClick={onMenuClick} />
           {isDark ? <LogoLight /> : <Logo />}
         </NavigatorSet>
         {/*알람 / 마이페이지 */}

--- a/src/components/search-filter/SearchFilter.tsx
+++ b/src/components/search-filter/SearchFilter.tsx
@@ -1,0 +1,72 @@
+import styled from "@emotion/styled";
+import FilterListIcon from "@mui/icons-material/FilterList";
+import StatusButtonGroup from "../status-button/StatusButtonGroup"; // StatusButtonGroup 경로에 맞게 수정
+
+const Container = styled.div`
+  width: 1114px;
+  height: 71px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0px 28px;
+  border-radius: 500px;
+  background-color: var(--gray1-background);
+`;
+
+const SearchBar = styled.div`
+  display: flex;
+  align-items: center;
+  width: 352px;
+  height: 35px;
+  border-radius: 500px;
+  background-color: white;
+  padding: 0 10px;
+`;
+
+const SearchText = styled.span`
+  font-size: 14px;
+  color: var(--gray6-header);
+  margin-right: 8px;
+  margin-left: 8px;
+`;
+
+const SearchInput = styled.input`
+  border: none;
+  outline: none;
+  flex-grow: 1;
+  font-size: 14px;
+  padding: 0 8px;
+  color: var(--gray4-placeholder-loq);
+  &::placeholder{
+    color: var(--gray4-placeholder-low)
+  }
+`;
+
+const FilterIcon = styled(FilterListIcon)`
+  color: gray5-lowText;
+  cursor: pointer;
+`;
+
+const StatusButtonGroupContainer = styled.div`
+  display: flex;
+`;
+
+const SearchFilterBar = () => {
+  return (
+    <Container>
+      {/* 왼쪽 서치바 */}
+      <SearchBar>
+        <SearchText>해시태그</SearchText>
+        <SearchInput placeholder="졸업" />
+        <FilterIcon />
+      </SearchBar>
+
+      {/* 오른쪽 상태 버튼 그룹 */}
+      <StatusButtonGroupContainer>
+        <StatusButtonGroup />
+      </StatusButtonGroupContainer>
+    </Container>
+  );
+};
+
+export default SearchFilterBar;

--- a/src/components/side-navigator/SideNavigator.tsx
+++ b/src/components/side-navigator/SideNavigator.tsx
@@ -1,13 +1,18 @@
 import styled from "@emotion/styled";
 import UserInfo from "./UserInfo";
+import { forwardRef } from "react";
 
 const SideNavContainer = styled.div`
   width: 250px;
   height: 100vh;
+  position: fixed;
+  top: 0;
+  left: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
   border-right: 1px solid var(--gray3-border);
+  background-color: var(--white);
 
   @media (max-width: 768px) {
     width: 200px;
@@ -34,9 +39,9 @@ const MenuContent = styled.div`
   }
 `;
 
-const SideNavigator = () => {
+const SideNavigator = forwardRef<HTMLDivElement>((_, ref) => {
   return (
-    <SideNavContainer>
+    <SideNavContainer ref={ref}>
       <UserInfo />
       <Menu>
         <MenuSubTitle>조회 / 신청</MenuSubTitle>
@@ -53,6 +58,6 @@ const SideNavigator = () => {
       </Menu>
     </SideNavContainer>
   );
-};
+});
 
 export default SideNavigator;

--- a/src/components/status-button/StatusButtonGroup.tsx
+++ b/src/components/status-button/StatusButtonGroup.tsx
@@ -4,13 +4,13 @@ import styled from "@emotion/styled";
 
 const ButtonGroupContainer = styled.div`
   display: flex;
-  gap: 8px;
+  gap: 12px;
   width: 296px;
   height: 29px;
 `;
 
 const StatusButtonGroup = () => {
-  const [selectedType, setSelectedType] = useState<StatusType | null>(null);
+  const [selectedType, setSelectedType] = useState<StatusType>("inProgress"); // 초기 상태 설정
 
   const handleClick = (type: StatusType) => {
     setSelectedType(type);

--- a/src/pages/SideNavConnect.tsx
+++ b/src/pages/SideNavConnect.tsx
@@ -32,7 +32,6 @@ const CloseButton = styled.button`
   cursor: pointer;
   z-index: 1001;
   color: black;
-
   @media (min-width: 480px) {
     display: none;
   }
@@ -41,7 +40,7 @@ const CloseButton = styled.button`
 const SideNavConnect = () => {
   const [isSideNavOpen, setIsSideNavOpen] = useState(false);
   const isMobileScreen = window.innerWidth <= 480;
-  
+
   // notificationIconRef를 useRef로 생성
   const notificationIconRef = useRef<HTMLDivElement | null>(null);
 

--- a/src/pages/SideNavConnect.tsx
+++ b/src/pages/SideNavConnect.tsx
@@ -1,0 +1,66 @@
+import { useState, useRef } from "react";
+import styled from "@emotion/styled";
+import Header from "../components/header/Header";
+import SideNavigator from "../components/side-navigator/SideNavigator";
+
+const AppContainer = styled.div`
+  display: flex;
+  position: relative;
+`;
+
+const SideNavWrapper = styled.div<{ isFullScreen: boolean }>`
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: ${(props) => (props.isFullScreen ? "100%" : "200px")};
+  background-color: white;
+  z-index: 1000;
+  transition: width 0.3s;
+  @media (max-width: 480px) {
+    width: 100%;
+  }
+`;
+
+const CloseButton = styled.button`
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  z-index: 1001;
+  color: black;
+
+  @media (min-width: 480px) {
+    display: none;
+  }
+`;
+
+const SideNavConnect = () => {
+  const [isSideNavOpen, setIsSideNavOpen] = useState(false);
+  const isMobileScreen = window.innerWidth <= 480;
+  
+  // notificationIconRef를 useRef로 생성
+  const notificationIconRef = useRef<HTMLDivElement | null>(null);
+
+  return (
+    <AppContainer>
+      <Header
+        onMenuClick={() => setIsSideNavOpen(true)}
+        onNotificationClick={() => console.log("Notification clicked")}
+        notificationIconRef={notificationIconRef} // 유효한 ref 전달
+      />
+
+      {isSideNavOpen && (
+        <SideNavWrapper isFullScreen={isMobileScreen}>
+          <CloseButton onClick={() => setIsSideNavOpen(false)}>×</CloseButton>
+          <SideNavigator />
+        </SideNavWrapper>
+      )}
+    </AppContainer>
+  );
+};
+
+export default SideNavConnect;


### PR DESCRIPTION
## 📝작업 내용
![image](https://github.com/user-attachments/assets/acb6ab98-412f-49ad-aa5f-fc563f4636de)

1.  검색-필터 바(SearchFilter) 컴포넌트 구현
  - 좌측 서치바(검색 텍스트, 입력 필드, 필터 아이콘)와 우측 상태 버튼 그룹(StatusButtonGroup)으로 구성
  - flexbox 레이아웃으로 정렬

3. [StatusButtonGroup.tsx] 선택 상태 초기화 옵션 수정
  - selectedType의 초기값이 null로 설정되어 있어, useState 초기값(기본값)을 'inProgress'로 설정되도록 수정

## 💬리뷰 요구사항
> 피그마 asset에 필터 로고가 없어 임의로 넣어두었습니다! 추후 수정하겠습니다.
> 피그마에 명시된 대로 고정된 width 값(1114px)을 사용했는데, 이 컴포넌트는 반응형 디자인에 포함되지 않는 게 맞는지 확인 부탁드립니다!
