### PR TITLE
Feat : 민원 검색 조회 페이지 / 드롭다운 컴포넌트 / 정렬 기준 컴포넌트 제작

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter } from "react-router-dom";
 import Layout from "./pages/Layout";
 import Home from "./pages/home/Home";
+import ComplaintSearch from "./pages/complaint-search/ComplaintSearch";
 
 export const router = createBrowserRouter([
   {
@@ -10,6 +11,10 @@ export const router = createBrowserRouter([
       {
         path: "",
         element: <Home />,
+      },
+      {
+        path: "complaint-search",
+        element: <ComplaintSearch />,
       },
     ],
   },

--- a/src/components/content/ContentList.tsx
+++ b/src/components/content/ContentList.tsx
@@ -3,6 +3,7 @@ import StatusDisplay from "../status-button/StatusDisplay";
 import CategoryTagGroup from "../category-tag/CategoryTagGroup";
 import { Article, Title } from "../../styles/ContentStyle";
 import { DataType } from "../../types/Type";
+import InteractionGroup from "../interaction/InteractionGroup";
 
 interface ContentListProps {
   data: DataType;
@@ -46,7 +47,7 @@ const ContentList = ({ data }: ContentListProps) => {
           <StatusDisplay type={data.status} />
           <CategoryTagGroup tagArray={data.category} />
         </InfoContainer>
-        {/*Interaction */}
+        <InteractionGroup likes={data.likes} bookmarks={data.bookmarks} />
       </StatusContainer>
       <Title>{data.title}</Title>
       <Article line={ARTICLE_LINE}>{data.content}</Article>

--- a/src/components/drop-down/DropDown.tsx
+++ b/src/components/drop-down/DropDown.tsx
@@ -1,0 +1,97 @@
+import styled from "@emotion/styled";
+import { useEffect, useRef, useState } from "react";
+import { SvgIcon, SvgIconProps } from "@mui/material";
+import KeyboardArrowDownRoundedIcon from "@mui/icons-material/KeyboardArrowDownRounded";
+
+interface DropDownProps {
+  options: string[];
+}
+interface OptionProps {
+  isOpen: boolean;
+}
+const DropBox = styled.ul<OptionProps>`
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  padding: 0.2rem 0.4rem;
+  min-width: 120px;
+  min-height: 30px;
+  border: 1px solid var(--gray3-border);
+  border-radius: 4px;
+  gap: 0.5rem;
+  color: var(--gray5-lowText);
+  background-color: var(--white);
+  z-index: 10;
+  transform: 0.3 ease;
+  &:focus {
+    outline: none;
+  }
+  cursor: pointer;
+  position: relative;
+`;
+const OptionContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: 0.3rem;
+  position: absolute;
+`;
+const Options = styled.li`
+  color: var(--gray5-lowText);
+  width: 100%;
+`;
+const DropDownIcon = styled(SvgIcon)<SvgIconProps>`
+  fill: var(--gray5-lowText);
+  position: absolute;
+  right: 0;
+`;
+
+const DropDown = ({ options }: DropDownProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [data, setData] = useState(options[0]);
+
+  const handleOpenClose = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setIsOpen((prev) => !prev);
+  };
+
+  const handleClick = (option: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    setData(option);
+    setIsOpen(false);
+  };
+
+  const dropDownRef = useRef<HTMLUListElement>(null);
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        dropDownRef.current &&
+        !dropDownRef.current.contains(e.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  return (
+    <DropBox isOpen={isOpen} onClick={handleOpenClose} ref={dropDownRef}>
+      <OptionContainer>
+        {isOpen
+          ? options.map((i, index) => (
+              <Options key={index} onClick={(e) => handleClick(i, e)}>
+                {i}
+              </Options>
+            ))
+          : data}
+      </OptionContainer>
+      <DropDownIcon
+        onClick={handleOpenClose}
+        component={KeyboardArrowDownRoundedIcon}
+      />
+    </DropBox>
+  );
+};
+
+export default DropDown;

--- a/src/components/drop-down/DropDown.tsx
+++ b/src/components/drop-down/DropDown.tsx
@@ -29,12 +29,24 @@ const DropBox = styled.ul<OptionProps>`
   cursor: pointer;
   position: relative;
 `;
-const OptionContainer = styled.div`
+const OptionContainer = styled.div<OptionProps>`
   display: flex;
   flex-direction: column;
+  padding: 0.3rem 0.4rem;
   width: 100%;
   gap: 0.3rem;
   position: absolute;
+  top: calc(100% + 1px);
+  left: 0;
+  border-left: ${(props) => props.isOpen && "1px solid var(--gray3-border)"};
+  border-right: ${(props) => props.isOpen && "1px solid var(--gray3-border)"};
+  border-bottom: ${(props) => props.isOpen && "1px solid var(--gray3-border)"};
+  border-end-start-radius: 4px;
+  border-end-end-radius: 4px;
+  background-color: var(--white);
+  max-height: ${({ isOpen }) => (isOpen ? "200px" : "0")};
+  overflow: hidden;
+  transition: 0.3s ease;
 `;
 const Options = styled.li`
   color: var(--gray5-lowText);
@@ -77,14 +89,14 @@ const DropDown = ({ options }: DropDownProps) => {
 
   return (
     <DropBox isOpen={isOpen} onClick={handleOpenClose} ref={dropDownRef}>
-      <OptionContainer>
-        {isOpen
-          ? options.map((i, index) => (
-              <Options key={index} onClick={(e) => handleClick(i, e)}>
-                {i}
-              </Options>
-            ))
-          : data}
+      {data}
+      <OptionContainer isOpen={isOpen}>
+        {isOpen &&
+          options.map((i, index) => (
+            <Options key={index} onClick={(e) => handleClick(i, e)}>
+              {i}
+            </Options>
+          ))}
       </OptionContainer>
       <DropDownIcon
         onClick={handleOpenClose}

--- a/src/components/sort-bar/SortBar.tsx
+++ b/src/components/sort-bar/SortBar.tsx
@@ -1,0 +1,37 @@
+import styled from "@emotion/styled";
+import DropDown from "../drop-down/DropDown";
+import SortStandard from "./sort-standard/SortStandard";
+
+const Container = styled.div`
+  max-width: 1114px;
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  border-bottom: 1px solid var(--gray2-subbtn);
+  padding-bottom: 1rem;
+`;
+const SortOptionContainer = styled.div`
+  display: flex;
+  gap: 0.5rem;
+`;
+const Divide = styled.pre`
+  color: var(--gray4-placeholder-low);
+`;
+
+const SortBar = () => {
+  const OPTION = ["1개월", "3개월", "6개월"];
+  return (
+    <Container>
+      <SortOptionContainer>
+        <SortStandard type="latest" />
+        <Divide>|</Divide>
+        <SortStandard type="scrap" />
+        <Divide>|</Divide>
+        <SortStandard type="likes" />
+      </SortOptionContainer>
+      <DropDown options={OPTION} />
+    </Container>
+  );
+};
+
+export default SortBar;

--- a/src/components/sort-bar/sort-standard/SortStandard.tsx
+++ b/src/components/sort-bar/sort-standard/SortStandard.tsx
@@ -1,0 +1,58 @@
+import styled from "@emotion/styled";
+import TimelineRoundedIcon from "@mui/icons-material/TimelineRounded";
+import BookmarkRoundedIcon from "@mui/icons-material/BookmarkRounded";
+import ThumbUpOffAltRoundedIcon from "@mui/icons-material/ThumbUpOffAltRounded";
+import { SvgIcon, SvgIconProps } from "@mui/material";
+
+interface SortStandardProps {
+  type: "latest" | "scrap" | "likes";
+}
+const Container = styled.div`
+  display: flex;
+  gap: 0.5rem;
+  cursor: pointer;
+  &:hover {
+    color: var(--gray6-black);
+    fill: var(--gray6-black);
+    & > svg {
+      fill: var(--gray6-black);
+    }
+    & > pre {
+      color: var(--gray6-black);
+    }
+  }
+`;
+const Icon = styled(SvgIcon)<SvgIconProps>`
+  fill: var(--gray5-lowText);
+  width: 24px;
+  height: 24px;
+`;
+const String = styled.pre`
+  color: var(--gray5-lowText);
+`;
+
+const SortStandard = ({ type }: SortStandardProps) => {
+  const match = {
+    latest: {
+      string: "최신순",
+      icon: TimelineRoundedIcon,
+    },
+    scrap: {
+      string: "스크랩순",
+      icon: BookmarkRoundedIcon,
+    },
+    likes: {
+      string: "좋아요순",
+      icon: ThumbUpOffAltRoundedIcon,
+    },
+  };
+
+  return (
+    <Container>
+      <Icon component={match[type].icon}></Icon>
+      <String>{match[type].string}</String>
+    </Container>
+  );
+};
+
+export default SortStandard;

--- a/src/pages/complaint-search/ComplaintSearch.tsx
+++ b/src/pages/complaint-search/ComplaintSearch.tsx
@@ -1,0 +1,76 @@
+import styled from "@emotion/styled";
+import { SvgIcon, SvgIconProps } from "@mui/material";
+import SearchRoundedIcon from "@mui/icons-material/SearchRounded";
+import SearchBar from "../../components/search-bar/SearchBar";
+import ContentList from "../../components/content/ContentList";
+import { mockData } from "../../mockData";
+import { motion } from "framer-motion";
+
+const SearchArea = styled.div`
+  position: absolute;
+  left: 0;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;
+const Background = styled.div`
+  width: 100%;
+  background-color: var(--primary);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 0;
+  gap: 2rem;
+`;
+const SearchIcon = styled(SvgIcon)<SvgIconProps>`
+  fill: var(--disabled-primary);
+  width: 30px;
+  height: 30px;
+`;
+const SearchTitleContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0;
+`;
+const SearchKeyword = styled.h1`
+  color: var(--white);
+`;
+const Title = styled.h2`
+  color: var(--gray3-border);
+`;
+const AnimationContainer = styled(motion.div)``;
+
+const ComplaintSearch = () => {
+  //검색어 임시
+  const SEARCH_KEYWORD = "도서관 냉난방";
+  return (
+    <>
+      <SearchArea>
+        <Background>
+          <SearchTitleContainer>
+            <SearchIcon component={SearchRoundedIcon} />
+            <AnimationContainer
+              initial={{ opacity: 0, y: -10 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: 10 }}
+              transition={{ duration: 0.5 }}
+            >
+              <SearchKeyword>"{SEARCH_KEYWORD}"</SearchKeyword>
+            </AnimationContainer>
+            <Title>민원 검색 결과</Title>
+          </SearchTitleContainer>
+          <SearchBar />
+        </Background>
+        {mockData.map((i, index) => (
+          <ContentList data={i} key={index} />
+        ))}
+      </SearchArea>
+    </>
+  );
+};
+
+export default ComplaintSearch;

--- a/src/pages/complaint-search/ComplaintSearch.tsx
+++ b/src/pages/complaint-search/ComplaintSearch.tsx
@@ -5,6 +5,7 @@ import SearchBar from "../../components/search-bar/SearchBar";
 import ContentList from "../../components/content/ContentList";
 import { mockData } from "../../mockData";
 import { motion } from "framer-motion";
+import SortBar from "../../components/sort-bar/SortBar";
 
 const SearchArea = styled.div`
   position: absolute;
@@ -14,6 +15,7 @@ const SearchArea = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: 1.5rem;
 `;
 const Background = styled.div`
   width: 100%;
@@ -44,32 +46,39 @@ const Title = styled.h2`
 `;
 const AnimationContainer = styled(motion.div)``;
 
+const ContentContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
 const ComplaintSearch = () => {
   //검색어 임시
   const SEARCH_KEYWORD = "도서관 냉난방";
   return (
-    <>
-      <SearchArea>
-        <Background>
-          <SearchTitleContainer>
-            <SearchIcon component={SearchRoundedIcon} />
-            <AnimationContainer
-              initial={{ opacity: 0, y: -10 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: 10 }}
-              transition={{ duration: 0.5 }}
-            >
-              <SearchKeyword>"{SEARCH_KEYWORD}"</SearchKeyword>
-            </AnimationContainer>
-            <Title>민원 검색 결과</Title>
-          </SearchTitleContainer>
-          <SearchBar />
-        </Background>
+    <SearchArea>
+      <Background>
+        <SearchTitleContainer>
+          <SearchIcon component={SearchRoundedIcon} />
+          <AnimationContainer
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 10 }}
+            transition={{ duration: 0.5 }}
+          >
+            <SearchKeyword>"{SEARCH_KEYWORD}"</SearchKeyword>
+          </AnimationContainer>
+          <Title>민원 검색 결과</Title>
+        </SearchTitleContainer>
+        <SearchBar />
+      </Background>
+
+      <ContentContainer>
+        <SortBar />
         {mockData.map((i, index) => (
           <ContentList data={i} key={index} />
         ))}
-      </SearchArea>
-    </>
+      </ContentContainer>
+    </SearchArea>
   );
 };
 


### PR DESCRIPTION
## 📝작업 내용
### 정렬기준 컴포넌트
![image](https://github.com/user-attachments/assets/3ab85a42-d4d2-43db-a38c-a8eadee4ebab)

**사용방법**
* 해당 컴포넌트에 type을 전달 (latest : 최신순 / scrap : 스크랩순 / likes : 좋아요순)
* 새로운 정렬 타입을 추가하고 싶다면, match 객체에 추가하면 됨

### 드롭다운 컴포넌트
![image](https://github.com/user-attachments/assets/05e87eaa-be98-45dd-ba20-7cc0b4b97a77)
기존 select 태그로는 원하는 디자인을 구현하기엔 한계가 있기에 따로 드롭다운 컴포넌트를 제작함

**위 두 컴포넌트가 합쳐진 SortBar 컴포넌트 제작**

### 민원검색 조회 페이지
![image](https://github.com/user-attachments/assets/c9282822-86f4-452f-8e38-7e013a47c31b)

* 주소 : /complaint-search

### 그 외
* ContentList에 좋아요 및 스크랩이 보이지 않은 문제 해결

## 추가 작업이 필요한 사항
* 페이지네이션 기능의 추가 (현서님 담당)
* 필터링 기능 추가
* 민원 검색 / 전체 검색 등 상단의 파란색 레이아웃을 사용하는 페이지가 다수 있음 : styles로 분리해서 사용하면 좋을 듯 함

## 💬리뷰 요구사항

