### PR TITLE
Feat, Refactor : 민원 이전 단계 렌더링 및 페이지를 벗어날 경우 경고 기능

### DIFF
--- a/src/components/category-select/CategorySelect.tsx
+++ b/src/components/category-select/CategorySelect.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import SubCategory from "./SubCategory";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { categoryName } from "../../utils/SubCategoryContent";
 import { motion } from "framer-motion";
 
@@ -38,9 +38,6 @@ const Category = styled.button<CategoryProps>`
   justify-content: center;
   align-items: center;
   cursor: pointer;
-  &:hover {
-    color: ${(props) => !props.isClick && "var(--primary)"};
-  }
   color: ${(props) => props.isClick && "var(--white)"};
   z-index: 100;
 `;
@@ -65,15 +62,35 @@ const CategorySelect = ({ usage }: UsageProps) => {
   const CATEGORY = ["facility", "degree", "career", "school"] as const;
   const CATEGORY_CONTENT = ["시설/설비", "대학원", "진로/취업", "학교생활"];
 
-  const [category, setCategory] =
-    useState<keyof typeof categoryName>("facility");
+  const storedMajorCategory = sessionStorage.getItem("majorCategory");
+  const [category, setCategory] = useState<keyof typeof categoryName>(
+    storedMajorCategory &&
+      categoryName[storedMajorCategory as keyof typeof categoryName]
+      ? (storedMajorCategory as keyof typeof categoryName)
+      : "facility"
+  );
 
   const [isClick, setIsClick] = useState({
-    facility: true,
+    facility: true, // 첫 선택 값이 true로 설정
     degree: false,
     career: false,
     school: false,
   });
+
+  useEffect(() => {
+    if (
+      storedMajorCategory &&
+      CATEGORY.includes(storedMajorCategory as keyof typeof categoryName)
+    ) {
+      setIsClick(() => ({
+        facility: false,
+        degree: false,
+        career: false,
+        school: false,
+        [storedMajorCategory]: true,
+      }));
+    }
+  }, [storedMajorCategory]);
 
   const handleCategorySelect = (e: React.MouseEvent<HTMLButtonElement>) => {
     const value = e.currentTarget.getAttribute("data-category")!;
@@ -84,9 +101,11 @@ const CategorySelect = ({ usage }: UsageProps) => {
         for (let key in newPrev) {
           newPrev[key as keyof typeof categoryName] = key === value;
         }
+        sessionStorage.setItem("majorCategory", value);
         return newPrev;
       });
     }
+    sessionStorage.removeItem("majorCategory");
   };
 
   return (

--- a/src/components/category-select/SubCategory.tsx
+++ b/src/components/category-select/SubCategory.tsx
@@ -42,11 +42,14 @@ const SubCategory = (props: SubCategoryProps) => {
   const { category, usage } = props;
   const subCategoryField = categoryName[category];
 
-  const { setCategoryName } = useComplaintStore((state) => state);
-
   const context = usage === "filter" ? useContext(ViewContext) : null;
 
-  const [subCategory, setSubCategory] = useState<CategoryValue>();
+  const storedValue = sessionStorage.getItem("category");
+  const [subCategory, setSubCategory] = useState<CategoryValue | null>(
+    storedValue ? (storedValue as CategoryValue) : null
+  );
+
+  //필터링 (usage : filter)
   const handleSubCategorySelect = (value: CategoryValue) => {
     if (subCategory === value) {
       setSubCategory(undefined);
@@ -57,14 +60,19 @@ const SubCategory = (props: SubCategoryProps) => {
     context?.handleFilterOptions("category", value);
   };
 
+  //일반 선택 (usage : normal)
+  const { setCategoryName } = useComplaintStore((state) => state);
+
   const handleClick = (value: CategoryValue) => {
     if (subCategory === value) {
       setSubCategory(undefined);
       setCategoryName("");
+      sessionStorage.removeItem("category");
       return;
     }
     setSubCategory(value);
     setCategoryName(value);
+    sessionStorage.setItem("category", `${value}`);
   };
 
   const handleClickHandler =

--- a/src/components/check-box/CheckBox.tsx
+++ b/src/components/check-box/CheckBox.tsx
@@ -1,5 +1,4 @@
 import styled from "@emotion/styled";
-import { useState } from "react";
 
 interface hasErroProps {
   hasError: boolean;
@@ -7,7 +6,8 @@ interface hasErroProps {
 type CheckboxProps = {
   text: string;
   hasError: boolean;
-  onChange: (checked: boolean) => void;
+  handleIsChecked: (isChecked: boolean) => void;
+  isChecked: boolean;
 };
 
 const StyledLabel = styled.label<hasErroProps>`
@@ -43,21 +43,24 @@ const ConfirmationMessage = styled.p<hasErroProps>`
     props.hasError ? "var(--error-dark)" : "var(--gray5-lowText)"};
 `;
 
-function Checkbox({ text, hasError, onChange }: CheckboxProps) {
-  const [isChecked, setIsChecked] = useState(false);
-  const handleCheck = () => {
-    const newCheckState = !isChecked;
-    setIsChecked((prev) => !prev);
-    onChange(newCheckState);
+function Checkbox({
+  text,
+  hasError,
+  handleIsChecked,
+  isChecked,
+}: CheckboxProps) {
+  const handleChange = () => {
+    const newIsChecked = !isChecked;
+    handleIsChecked(newIsChecked);
   };
-
   return (
     <StyledLabel htmlFor={text} hasError={hasError}>
       <StyledInput
         type="checkbox"
         id={text}
         name={text}
-        onChange={handleCheck}
+        onChange={handleChange}
+        checked={isChecked}
       />
       <ConfirmationMessage hasError={hasError}>{text}</ConfirmationMessage>
     </StyledLabel>

--- a/src/components/file-upload/FileUploadField.tsx
+++ b/src/components/file-upload/FileUploadField.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from "react";
 import styled from "@emotion/styled";
 import Button from "../button/Button";
 import SvgIcon, { SvgIconProps } from "@mui/material/SvgIcon";
 import CancelRoundedIcon from "@mui/icons-material/CancelRounded";
+import useComplaintStore from "../../store/useComplaintStore";
 
 const FileInputContainer = styled.div`
   display: flex;
@@ -78,33 +78,44 @@ const DeleteFileButton = styled(SvgIcon)<SvgIconProps>`
   }
 `;
 
-interface FileUploadFieldProps {
-  onFileChange: (file: File[] | null) => void;
-}
-
-const FileUploadField = ({ onFileChange }: FileUploadFieldProps) => {
+const FileUploadField = () => {
   const INVALID_EXTENSION = "Jpg / Jpeg / Png 파일만 업로드 할 수 있습니다";
 
-  //file view
-  const [selectedFile, setSelectedFile] = useState<File[] | null>(null);
+  const { attachments, setAttachments } = useComplaintStore((state) => state);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    e.preventDefault();
     const fileList = e.target.files;
-    if (fileList) {
-      const newFiles = Array.from(fileList);
+    const files = fileList && Array.from(fileList);
 
-      setSelectedFile((prev) => (prev ? [...prev, ...newFiles] : newFiles));
-      onFileChange(newFiles);
+    if (files) {
+      setAttachments((prev: File[] | null) =>
+        prev ? [...prev, ...files] : [...files]
+      );
+
+      const newFilesData = files.map((file) => ({
+        name: file.name,
+        size: file.size,
+        type: file.type,
+        lastModified: file.lastModified,
+      }));
+
+      const storedFiles = sessionStorage.getItem("files");
+      const filesArray = storedFiles ? JSON.parse(storedFiles) : [];
+      const updatedFilesArray = [...filesArray, ...newFilesData];
+      sessionStorage.setItem("files", JSON.stringify(updatedFilesArray));
     }
   };
 
   const handleFileRemove = (index: number) => {
-    if (selectedFile) {
-      const updatedFiles = Array.from(selectedFile);
+    if (attachments) {
+      const updatedFiles = Array.from(attachments);
       updatedFiles.splice(index, 1);
-      setSelectedFile(updatedFiles ? updatedFiles : null);
-      onFileChange(updatedFiles);
+      console.log(updatedFiles);
+      sessionStorage.setItem("files", JSON.stringify(updatedFiles));
+    }
+    const storedFiles = sessionStorage.getItem("files");
+    if (storedFiles && JSON.parse(storedFiles).length === 0) {
+      sessionStorage.removeItem("files");
     }
   };
 
@@ -137,8 +148,8 @@ const FileUploadField = ({ onFileChange }: FileUploadFieldProps) => {
           </div>
 
           <FileDetailsContainer>
-            {selectedFile &&
-              Array.from(selectedFile).map((file, index) => (
+            {attachments &&
+              Array.from(attachments).map((file, index) => (
                 <FileNameContainer key={index}>
                   <FileName>{file.name}</FileName>
                   <DeleteFileButton
@@ -147,7 +158,7 @@ const FileUploadField = ({ onFileChange }: FileUploadFieldProps) => {
                   />
                 </FileNameContainer>
               ))}
-            {!selectedFile?.length && <FileName>{INVALID_EXTENSION}</FileName>}
+            {!attachments?.length && <FileName>{INVALID_EXTENSION}</FileName>}
           </FileDetailsContainer>
         </FileInputWrapper>
       </InputInfoContainer>

--- a/src/components/file-upload/FileUploadField.tsx
+++ b/src/components/file-upload/FileUploadField.tsx
@@ -108,10 +108,15 @@ const FileUploadField = () => {
 
   const handleFileRemove = (index: number) => {
     if (attachments) {
-      const updatedFiles = Array.from(attachments);
-      updatedFiles.splice(index, 1);
-      console.log(updatedFiles);
-      sessionStorage.setItem("files", JSON.stringify(updatedFiles));
+      const updatedFiles = attachments.filter((_, idx) => idx !== index);
+      setAttachments(() => updatedFiles);
+      const newFilesData = updatedFiles.map((file) => ({
+        name: file.name,
+        size: file.size,
+        type: file.type,
+        lastModified: file.lastModified,
+      }));
+      sessionStorage.setItem("files", JSON.stringify(newFilesData));
     }
     const storedFiles = sessionStorage.getItem("files");
     if (storedFiles && JSON.parse(storedFiles).length === 0) {

--- a/src/components/file-upload/FileUploadField.tsx
+++ b/src/components/file-upload/FileUploadField.tsx
@@ -82,7 +82,6 @@ const FileUploadField = () => {
   const INVALID_EXTENSION = "Jpg / Jpeg / Png 파일만 업로드 할 수 있습니다";
 
   const { attachments, setAttachments } = useComplaintStore((state) => state);
-
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const fileList = e.target.files;
     const files = fileList && Array.from(fileList);
@@ -110,6 +109,7 @@ const FileUploadField = () => {
     if (attachments) {
       const updatedFiles = attachments.filter((_, idx) => idx !== index);
       setAttachments(() => updatedFiles);
+
       const newFilesData = updatedFiles.map((file) => ({
         name: file.name,
         size: file.size,
@@ -118,14 +118,15 @@ const FileUploadField = () => {
       }));
       sessionStorage.setItem("files", JSON.stringify(newFilesData));
     }
-    const storedFiles = sessionStorage.getItem("files");
-    if (storedFiles && JSON.parse(storedFiles).length === 0) {
-      sessionStorage.removeItem("files");
-    }
   };
-
   const handleFileClick = () => {
     document.getElementById("file")?.click();
+  };
+
+  const handleFileRemoveAndClearInput = (index: number) => {
+    handleFileRemove(index);
+    const fileInput = document.getElementById("file") as HTMLInputElement;
+    fileInput.value = "";
   };
 
   return (
@@ -159,7 +160,7 @@ const FileUploadField = () => {
                   <FileName>{file.name}</FileName>
                   <DeleteFileButton
                     component={CancelRoundedIcon}
-                    onClick={() => handleFileRemove(index)}
+                    onClick={() => handleFileRemoveAndClearInput(index)}
                   />
                 </FileNameContainer>
               ))}

--- a/src/components/form/ComplaintsForm.tsx
+++ b/src/components/form/ComplaintsForm.tsx
@@ -3,6 +3,7 @@ import Input from "../input/Input";
 import TextArea from "../input/TextArea";
 import FileUploadField from "../file-upload/FileUploadField";
 import useComplaintStore from "../../store/useComplaintStore";
+import { removeBlankContent } from "../../utils/SessionStorage";
 
 interface ComplaintsFormProps {
   isEssentialWrite: {
@@ -37,6 +38,9 @@ const ComplaintsForm = ({ isEssentialWrite }: ComplaintsFormProps) => {
     setContentExpect,
     setAttachment,
   } = useComplaintStore((state) => state);
+  const { title, contentDir, contentProb, contentExpect } = useComplaintStore(
+    (state) => state
+  );
 
   const handleFileChange = (file: File[] | null) => {
     if (file) {
@@ -61,6 +65,11 @@ const ComplaintsForm = ({ isEssentialWrite }: ComplaintsFormProps) => {
     if (formType === "contentDir") {
       setContentDir(e.target.value);
     }
+    if (formType === "contentExpect") {
+      setContentExpect(e.target.value);
+    }
+    sessionStorage.setItem(formType, e.target.value);
+    removeBlankContent(e, formType);
   };
 
   return (
@@ -73,6 +82,7 @@ const ComplaintsForm = ({ isEssentialWrite }: ComplaintsFormProps) => {
           height="40px"
           onChange={(e) => handleChange(e, "title")}
           hasError={!isEssentialWrite.title}
+          value={title}
         />
       </FormInputGroup>
       <FormInputGroup>
@@ -82,6 +92,7 @@ const ComplaintsForm = ({ isEssentialWrite }: ComplaintsFormProps) => {
           isRequired={true}
           onChange={(e) => handleChange(e, "contentProb")}
           hasError={!isEssentialWrite.contentProb}
+          value={contentProb}
         />
       </FormInputGroup>
       <FormInputGroup>
@@ -91,13 +102,15 @@ const ComplaintsForm = ({ isEssentialWrite }: ComplaintsFormProps) => {
           isRequired={true}
           onChange={(e) => handleChange(e, "contentDir")}
           hasError={!isEssentialWrite.contentDir}
+          value={contentDir}
         />
       </FormInputGroup>
       <FormInputGroup>
         <TextArea
           label="기대효과"
           placeholder="내용을 입력해주세요"
-          onChange={(e) => setContentExpect(e.target.value)}
+          onChange={(e) => handleChange(e, "contentExpect")}
+          value={contentExpect}
         />
       </FormInputGroup>
       <FileUploadField onFileChange={handleFileChange} />

--- a/src/components/form/ComplaintsForm.tsx
+++ b/src/components/form/ComplaintsForm.tsx
@@ -31,24 +31,11 @@ const FormInputGroup = styled.div`
 `;
 
 const ComplaintsForm = ({ isEssentialWrite }: ComplaintsFormProps) => {
-  const {
-    setTitle,
-    setContentDir,
-    setContentProb,
-    setContentExpect,
-    setAttachment,
-  } = useComplaintStore((state) => state);
+  const { setTitle, setContentDir, setContentProb, setContentExpect } =
+    useComplaintStore((state) => state);
   const { title, contentDir, contentProb, contentExpect } = useComplaintStore(
     (state) => state
   );
-
-  const handleFileChange = (file: File[] | null) => {
-    if (file) {
-      setAttachment((prev: File[] | null) =>
-        prev ? [...prev, ...file] : [...file]
-      );
-    }
-  };
 
   const handleChange = (
     e:
@@ -113,7 +100,7 @@ const ComplaintsForm = ({ isEssentialWrite }: ComplaintsFormProps) => {
           value={contentExpect}
         />
       </FormInputGroup>
-      <FileUploadField onFileChange={handleFileChange} />
+      <FileUploadField />
     </FormContainer>
   );
 };

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -67,6 +67,7 @@ const Input = ({
   isRequired = false,
   onChange,
   hasError,
+  value,
 }: InputProps) => {
   return (
     <Container>
@@ -80,6 +81,7 @@ const Input = ({
         height={height}
         onChange={onChange}
         hasError={hasError}
+        value={value}
       />
     </Container>
   );

--- a/src/components/input/TextArea.tsx
+++ b/src/components/input/TextArea.tsx
@@ -11,6 +11,7 @@ interface TextAreaProps extends InfoTextAreaProps {
   isRequired?: boolean;
   hasError?: boolean;
   onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  value?: string;
 }
 
 const TextAreaContainer = styled.div`
@@ -67,6 +68,7 @@ const TextArea = ({
   isRequired = false,
   hasError = false,
   onChange,
+  value,
 }: TextAreaProps) => {
   return (
     <TextAreaContainer>
@@ -79,6 +81,7 @@ const TextArea = ({
         height={height}
         onChange={onChange}
         hasError={hasError}
+        value={value}
       />
     </TextAreaContainer>
   );

--- a/src/components/rec-hashtag/RecHashTag.tsx
+++ b/src/components/rec-hashtag/RecHashTag.tsx
@@ -46,13 +46,19 @@ const RecHashTag = ({ contentTotal }: RecHashTagProps) => {
   const [tagArray, setTagArray] = useState<string[]>([]);
   const [showAlert, setShowAlert] = useState(false);
 
+  const [hasError, setHasError] = useState(false);
+
   useEffect(() => {
     getHashtags(contentTotal)
       .then((res) => {
         setHashtagData(res.split(", "));
         setIsLoading(false);
       })
-      .catch((error) => console.log(error));
+      .catch((error) => {
+        console.log(error);
+        setIsLoading(false);
+        setHasError(true);
+      });
   }, []);
 
   return (
@@ -76,6 +82,9 @@ const RecHashTag = ({ contentTotal }: RecHashTagProps) => {
               setShowAlert={setShowAlert}
             />
           ))}
+          {!isLoading && hasError && (
+            <div>사용할 수 있는 크레딧이 초과되었습니다</div>
+          )}
         </HashTagButton>
       )}
     </HashTagContainer>

--- a/src/hooks/usePrompt.ts
+++ b/src/hooks/usePrompt.ts
@@ -1,0 +1,23 @@
+import { useEffect } from "react";
+import { useBlocker } from "react-router-dom";
+
+const CONFIRM_MESSAGE =
+  "페이지를 이동하시겠습니까? 작성 내용은 저장되지 않습니다";
+
+const usePrompt = () => {
+  const blocker = useBlocker(({ currentLocation, nextLocation }) => {
+    const condition = !nextLocation.pathname.includes("complaint-request");
+    return condition && currentLocation.pathname !== nextLocation.pathname;
+  });
+
+  useEffect(() => {
+    if (blocker.state !== "blocked") return;
+    if (window.confirm(CONFIRM_MESSAGE)) {
+      blocker.proceed();
+    } else {
+      blocker.reset();
+    }
+  }, [blocker.state]);
+};
+
+export default usePrompt;

--- a/src/pages/Layout.tsx
+++ b/src/pages/Layout.tsx
@@ -1,6 +1,8 @@
 import { Outlet, useLocation } from "react-router-dom";
 import styled from "@emotion/styled";
 import HeaderProvider from "../components/header/HeaderProvider";
+import { useEffect } from "react";
+import useComplaintStore from "../store/useComplaintStore";
 
 const Wrap = styled.div`
   width: 100%;
@@ -26,6 +28,27 @@ const ColoredLayout = styled.div<{ bgc: string }>`
 const Layout = () => {
   const path = useLocation().pathname;
   const backgroundColor = path === "/" ? "var(--primary)" : "none";
+
+  const {
+    setTitle,
+    setContentDir,
+    setContentProb,
+    setContentExpect,
+    setCategoryName,
+    setAttachments,
+  } = useComplaintStore((state) => state);
+
+  useEffect(() => {
+    if (!path.includes("complaint-request")) {
+      sessionStorage.clear();
+      setTitle("");
+      setContentDir("");
+      setContentProb("");
+      setContentExpect("");
+      setAttachments(() => []);
+      setCategoryName("");
+    }
+  }, [path]);
   return (
     <Wrap>
       <ColoredLayout bgc={backgroundColor}>

--- a/src/pages/complaint-apply/ApplicationLayout.tsx
+++ b/src/pages/complaint-apply/ApplicationLayout.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import styled from "@emotion/styled";
 import ProgressBar from "../../components/progress-line/ProgressBar";
 import MailRoundedIcon from "@mui/icons-material/MailRounded";
+import usePrompt from "../../hooks/\busePrompt";
 
 const LayoutContainer = styled.div`
   display: flex;
@@ -62,6 +63,8 @@ interface LayoutProps {
 }
 
 const ApplicationLayout: React.FC<LayoutProps> = ({ children, activeStep }) => {
+  usePrompt();
+
   return (
     <LayoutContainer>
       <Background />

--- a/src/pages/complaint-apply/apply-step/AcademicInfoStep.tsx
+++ b/src/pages/complaint-apply/apply-step/AcademicInfoStep.tsx
@@ -34,7 +34,10 @@ const AcademicInfoStep = () => {
     "학적 정보는 관리자에게 전송되며, 오직 민원 처리 목적으로만 사용됩니다";
   const NEXT_PAGE_URL = "../2";
 
-  const [isChecked, setIsChecked] = useState(false);
+  const storedValue = sessionStorage.getItem("isChecked");
+  const [isChecked, setIsChecked] = useState(
+    storedValue ? JSON.parse(storedValue) : false
+  );
   const [showAlert, setShowAlert] = useState(false);
 
   const navigate = useNavigate();
@@ -52,6 +55,10 @@ const AcademicInfoStep = () => {
     setIsChecked(isChecked);
     if (isChecked) {
       setShowAlert(false);
+      sessionStorage.setItem("isChecked", JSON.stringify(true));
+    }
+    if (!isChecked) {
+      sessionStorage.removeItem("isChecked");
     }
   };
 
@@ -74,7 +81,8 @@ const AcademicInfoStep = () => {
           <Checkbox
             text="확인했습니다"
             hasError={showAlert}
-            onChange={handleIsChecked}
+            isChecked={isChecked}
+            handleIsChecked={handleIsChecked}
           />
         </FormTitleContainer>
 

--- a/src/pages/complaint-apply/apply-step/CategorySelectionStep.tsx
+++ b/src/pages/complaint-apply/apply-step/CategorySelectionStep.tsx
@@ -29,6 +29,17 @@ const ButtonGroup = styled.div`
   gap: 1rem;
 `;
 
+const CategoryView = styled.div`
+  display: inline-flex;
+  padding: 0.5rem 3rem;
+  justify-content: center;
+  background-color: var(--primary);
+  color: var(--white);
+  margin-top: 1rem;
+  text-align: center;
+  border-radius: 8px;
+`;
+
 const CategorySelectionStep = () => {
   const PREV_PAGE_URL = "../1";
   const NEXT_PAGE_URL = "../3";
@@ -63,7 +74,10 @@ const CategorySelectionStep = () => {
             가장 연관이 깊은 1개의 카테고리(분류)를 선택해 주세요
           </FormTitle>
         </FormTitleContainer>
+
         <CategorySelect usage="normal" />
+        {categoryName && <CategoryView>{categoryName}</CategoryView>}
+
         <ButtonGroup>
           <Button
             content="이전"

--- a/src/store/useComplaintStore.ts
+++ b/src/store/useComplaintStore.ts
@@ -1,12 +1,13 @@
 import { create } from "zustand";
 import { ComplaintForm } from "../types/Type";
 
+const storedCategory = sessionStorage.getItem("category");
 const useComplaintStore = create<ComplaintForm>((set) => ({
   title: "",
   contentProb: "",
   contentDir: "",
   contentExpect: "",
-  categoryName: "",
+  categoryName: storedCategory ? storedCategory : "",
   tagName: "",
   attachments: [],
 

--- a/src/store/useComplaintStore.ts
+++ b/src/store/useComplaintStore.ts
@@ -2,11 +2,16 @@ import { create } from "zustand";
 import { ComplaintForm } from "../types/Type";
 
 const storedCategory = sessionStorage.getItem("category");
+const storedTitle = sessionStorage.getItem("title");
+const storeContentProb = sessionStorage.getItem("contentProb");
+const storeContentDir = sessionStorage.getItem("contentDir");
+const storeContentExpect = sessionStorage.getItem("contentExpect");
+
 const useComplaintStore = create<ComplaintForm>((set) => ({
-  title: "",
-  contentProb: "",
-  contentDir: "",
-  contentExpect: "",
+  title: storedTitle ? storedTitle : "",
+  contentProb: storeContentProb ? storeContentProb : "",
+  contentDir: storeContentDir ? storeContentDir : "",
+  contentExpect: storeContentExpect ? storeContentExpect : "",
   categoryName: storedCategory ? storedCategory : "",
   tagName: "",
   attachments: [],

--- a/src/store/useComplaintStore.ts
+++ b/src/store/useComplaintStore.ts
@@ -6,6 +6,15 @@ const storedTitle = sessionStorage.getItem("title");
 const storeContentProb = sessionStorage.getItem("contentProb");
 const storeContentDir = sessionStorage.getItem("contentDir");
 const storeContentExpect = sessionStorage.getItem("contentExpect");
+const rawFiles = sessionStorage.getItem("files");
+const parsedFiles = rawFiles ? JSON.parse(rawFiles) : [];
+const storedFiles = parsedFiles.map(
+  (file: { name: string; size: number; type: string; lastModified: number }) =>
+    new File([], file.name, {
+      type: file.type,
+      lastModified: file.lastModified,
+    })
+);
 
 const useComplaintStore = create<ComplaintForm>((set) => ({
   title: storedTitle ? storedTitle : "",
@@ -14,7 +23,7 @@ const useComplaintStore = create<ComplaintForm>((set) => ({
   contentExpect: storeContentExpect ? storeContentExpect : "",
   categoryName: storedCategory ? storedCategory : "",
   tagName: "",
-  attachments: [],
+  attachments: storedFiles ? storedFiles : [],
 
   setTitle: (title) => set({ title }),
   setContentProb: (contentProb) => set({ contentProb }),
@@ -22,7 +31,7 @@ const useComplaintStore = create<ComplaintForm>((set) => ({
   setContentExpect: (contentExpect) => set({ contentExpect }),
   setCategoryName: (categoryName) => set({ categoryName }),
   setTagName: (tagName) => set({ tagName }),
-  setAttachment: (update: (prev: File[] | null) => File[] | null) =>
+  setAttachments: (update: (prev: File[] | null) => File[] | null) =>
     set((state) => ({ attachments: update(state.attachments) })),
 }));
 

--- a/src/types/Type.ts
+++ b/src/types/Type.ts
@@ -127,5 +127,5 @@ export interface ComplaintForm {
   setContentExpect: (contentExpect: string) => void;
   setCategoryName: (categoryName: string | undefined) => void;
   setTagName: (tagName: string) => void;
-  setAttachment: (update: (prev: File[] | null) => File[] | null) => void;
+  setAttachments: (update: (prev: File[] | null) => File[] | null) => void;
 }

--- a/src/utils/SessionStorage.ts
+++ b/src/utils/SessionStorage.ts
@@ -1,0 +1,11 @@
+// 빈 칸인 경우 세선스토리지 비우기
+export const removeBlankContent = (
+  e:
+    | React.ChangeEvent<HTMLInputElement>
+    | React.ChangeEvent<HTMLTextAreaElement>,
+  formType: string
+) => {
+  if (e.target.value.length === 0) {
+    sessionStorage.removeItem(`${formType}`);
+  }
+};


### PR DESCRIPTION
## 📝작업 내용

### 민원 이전 단계 렌더링
- 세션스토리지를 사용하여 이전 버튼을 눌렀을 때 이전 내용이 사라지지 않고 렌더링 되도록 함
- 마찬가지로 새로고침 시에도 내용이 사라지지 않음 : 백엔드 전송시 오류가 생기지 않게끔 함

### 페이지를 벗어날 경우 경고
- useBlocker 사용
![image](https://github.com/user-attachments/assets/493337f1-e857-4e38-9dcd-b9123c4284da)

### 민원 작성 페이지에서 중복된 코드 제거
- 세션스토리지 및 전역 상태를 사용하면서 생긴 중복 코드 제거

## 💬리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
